### PR TITLE
毎日デプロイする

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,7 +9,7 @@ on:
     types:
       - completed
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
 
 permissions: {}
 


### PR DESCRIPTION
GitHub hosted runners を気遣って毎週デプロイだったけど、別に毎日デプロイでもええやろ！となった。

なお、毎日デプロイしたいのは、ビルドを契機に Zenn とか Docswell の feed を読んでいるから。