### PR TITLE
毎日のビルド・デプロイをスキップさせない

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -56,8 +56,7 @@ jobs:
 
       - if: ${{ steps.cache.outputs.cache-hit != 'true'}}
         run: npm ci
-      - if: ${{ steps.cache.outputs.cache-hit != 'true'}}
-        run: npm run build
+      - run: npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -28,7 +28,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    # NOTE: `workflow_run` イベントで起動した場合、前のワークフローが成功したときのみ実行
+    if: ${{ contains(fromJSON('["", "success"]'), github.event.workflow_run.conclusion) }}
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## 背景

#47 

## やったこと

以下の 3 つ:

- `github.event.workflow_run.conclusion` が空文字列の場合、ワークフローをスキップしないようにした。
- キャッシュがある場合は依存関係のインストールとビルドをスキップしていたが、常にビルドするようにした。
- `main` ブランチ以外のブランチでのデプロイをスキップしていたが、任意のブランチでデプロイ可能にした。