### PR TITLE
chore: Set npm minimum release age to 14 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=14


### PR DESCRIPTION
## 概要

サプライチェーン攻撃対策として、npm CLI の `min-release-age` を 14 日に設定する。

## 背景

Renovate 側には既に `renovate.json5` で `"minimumReleaseAge": "14 days"` を設定済みだが、ローカルでの `npm install` / `npm update` には効かないため、npm CLI 側にも同等の設定を入れる。

## 変更内容

- リポジトリルートに `.npmrc` を新規作成し、`min-release-age=14` を設定
  - npm v11.6 以降でサポートされる設定(単位: 日)
  - 公開から 14 日未満のバージョンは依存解決の対象から除外される
  - `npm ci` はロックファイル通りにインストールするため影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)