### PR TITLE
ci: 毎日デプロイしない

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,8 +8,6 @@ on:
     branches: ["main"]
     types:
       - completed
-  schedule:
-    - cron: "0 0 * * *"
 
 permissions: {}
 


### PR DESCRIPTION
購読する RSS の変更に追従するため毎日デプロイしていたが、購読する RSS は controllable で変更に気づくことが多いので、毎日自動でデプロイしなくてもよい。